### PR TITLE
Remove characteristic value usage

### DIFF
--- a/src/vue/apps/SelectCharacterSkillPrompt.vue
+++ b/src/vue/apps/SelectCharacterSkillPrompt.vue
@@ -43,11 +43,10 @@ function submitSelection(event: Event) {
 
 			<div class="skill-name">{{ characterSkillOption.skill.name }}</div>
 			<div class="skill-rank">{{ characterSkillOption.skill.systemData.rank }}</div>
-			<SkillRanks
-				:skill-value="characterSkillOption.skill.systemData.rank"
-				:characteristic-value="(characterSkillOption.actor.systemData as _NonVehicleDataModel).characteristics[characterSkillOption.skill.systemData.characteristic]"
-			/>
-		</div>
+                        <SkillRanks
+                                :skill-value="characterSkillOption.skill.systemData.rank"
+                        />
+                </div>
 
 		<button class="submit-button" @click="submitSelection" :disabled="selectedOptionIndex < 0"><Localized label="Genesys.Labels.Select" /></button>
 	</div>

--- a/src/vue/components/character/SkillRanks.vue
+++ b/src/vue/components/character/SkillRanks.vue
@@ -1,16 +1,14 @@
 <script lang="ts" setup>
 defineProps<{
-	skillValue: number;
-	characteristicValue: number;
+        skillValue: number;
 }>();
 </script>
 
 <template>
-	<div class="skill-ranks">
-		<div v-for="i in Math.max(0, 5 - Math.max(skillValue, characteristicValue))" :key="i" class="rank" />
-		<div v-for="i in Math.abs(skillValue - characteristicValue)" :key="i" class="rank ability" />
-		<div v-for="i in Math.min(skillValue, characteristicValue)" :key="i" class="rank proficiency" />
-	</div>
+        <div class="skill-ranks">
+                <div v-for="i in Math.max(0, 5 - skillValue)" :key="`a${i}`" class="rank" />
+                <div v-for="i in skillValue" :key="`p${i}`" class="rank proficiency" />
+        </div>
 </template>
 
 <style lang="scss" scoped>
@@ -34,13 +32,9 @@ defineProps<{
 			border-radius: 4px;
 		}
 
-		&.proficiency {
-			background: #ffe800;
-		}
-
-		&.ability {
-			background: #41ad49;
-		}
-	}
+                &.proficiency {
+                        background: #ffe800;
+                }
+        }
 }
 </style>

--- a/src/vue/sheets/actor/MinionSheet.vue
+++ b/src/vue/sheets/actor/MinionSheet.vue
@@ -100,7 +100,7 @@ async function deleteItem(item: GenesysItem) {
 
 					<a @click="rollSkill(skill)">
 						<span>{{ skill.name }}</span>
-						<SkillRanks :skill-value="Math.clamp(system.remainingMembers - 1, 0, 5)" :characteristic-value="system.characteristics[skill.systemData.characteristic]" />
+                                                <SkillRanks :skill-value="Math.clamp(system.remainingMembers - 1, 0, 5)" />
 					</a>
 				</ContextMenu>
 			</div>

--- a/src/vue/sheets/actor/character/CombatTab.vue
+++ b/src/vue/sheets/actor/character/CombatTab.vue
@@ -89,7 +89,7 @@ function damageForWeapon(weapon: GenesysItem<WeaponDataModel>) {
 					<div class="skill" v-for="skill in [skillForWeapon(weapon)]" :key="skill?.id ?? 'skill'">
 						<template v-if="skill">
 							{{ skill.name }}
-							<SkillRanks :skill-value="skill.systemData.rank" :characteristic-value="actor.systemData.characteristics[skill.systemData.characteristic]" />
+                                                        <SkillRanks :skill-value="skill.systemData.rank" />
 						</template>
 						<span v-else><Localized label="Genesys.Labels.SkillNotFound" /></span>
 					</div>

--- a/src/vue/sheets/actor/vehicle/SkillsTab.vue
+++ b/src/vue/sheets/actor/vehicle/SkillsTab.vue
@@ -175,7 +175,6 @@ async function openActorSheet(actor: GenesysActor) {
 								<span class="skill-rank">{{ skill.systemData.rank }}</span>
                                                                 <SkillRanks
                                                                         :skill-value="details.actor.type === 'minion' ? Math.max(0, (details.actor.systemData as MinionDataModel).remainingMembers - 1) : skill.systemData.rank"
-                                                                        :characteristic-value="0"
                                                                 />
 							</div>
 						</div>
@@ -203,10 +202,9 @@ async function openActorSheet(actor: GenesysActor) {
 							<div>{{ actorRoleSkill.role }}</div>
 							<div class="skill-content-details-skillRank">{{ actorRoleSkill.skill.systemData.rank }}</div>
 							<a @click="rollSkillForActor(actorRoleSkill.actor as GenesysActor<NonVehicleDataModel>, actorRoleSkill.skill as GenesysItem<SkillDataModel>)">
-								<SkillRanks
-									:skill-value="actorRoleSkill.actor.type === 'minion' ? Math.max(0, (actorRoleSkill.actor.systemData as MinionDataModel).remainingMembers - 1) : actorRoleSkill.skill.systemData.rank"
-									:characteristic-value="(actorRoleSkill.actor.systemData as NonVehicleDataModel).characteristics[actorRoleSkill.skill.systemData.characteristic]"
-								/>
+                                                                <SkillRanks
+                                                                        :skill-value="actorRoleSkill.actor.type === 'minion' ? Math.max(0, (actorRoleSkill.actor.systemData as MinionDataModel).remainingMembers - 1) : actorRoleSkill.skill.systemData.rank"
+                                                                />
 							</a>
 						</div>
 					</div>

--- a/src/vue/sheets/item/SkillSheet.vue
+++ b/src/vue/sheets/item/SkillSheet.vue
@@ -16,17 +16,6 @@ const system = computed(() => context.data.item.systemData);
 	<BasicItemSheet show-effects-tab>
 		<template v-slot:data>
 			<section class="data-grid">
-				<div class="row">
-					<label><Localized label="Genesys.Labels.Characteristic" /></label>
-					<select name="system.characteristic" :value="system.characteristic">
-						<option value="brawn"><Localized label="Genesys.Characteristics.Brawn" /></option>
-						<option value="agility"><Localized label="Genesys.Characteristics.Agility" /></option>
-						<option value="intellect"><Localized label="Genesys.Characteristics.Intellect" /></option>
-						<option value="cunning"><Localized label="Genesys.Characteristics.Cunning" /></option>
-						<option value="willpower"><Localized label="Genesys.Characteristics.Willpower" /></option>
-						<option value="presence"><Localized label="Genesys.Characteristics.Presence" /></option>
-					</select>
-				</div>
 
 				<div class="row">
 					<label><Localized label="Genesys.Labels.Category" /></label>


### PR DESCRIPTION
## Summary
- drop `characteristic-value` prop from SkillRanks
- clean up minion, combat, vehicle, and prompt components
- remove characteristic field from skill sheet

## Testing
- `yarn lint` *(fails: This package doesn't seem to be present in your lockfile)*
- `yarn test` *(fails: This package doesn't seem to be present in your lockfile)*

------
https://chatgpt.com/codex/tasks/task_e_685ed9f012e483219d5c37d8c3d56d31