### PR TITLE
fix parameter typing for createSkill

### DIFF
--- a/src/actor/sheets/CharacterSheet.ts
+++ b/src/actor/sheets/CharacterSheet.ts
@@ -431,7 +431,7 @@ export default class CharacterSheet extends VueSheet(GenesysActorSheet<Character
          *
          * @param skillData Data for the skill item to create.
          */
-        async createSkill(skillData: foundry.documents.ItemSource): Promise<GenesysItem<SkillDataModel> | undefined> {
+        async createSkill(skillData: foundry.data.ItemSource): Promise<GenesysItem<SkillDataModel> | undefined> {
                 if (skillData.type !== 'skill') {
                         return undefined;
                 }


### PR DESCRIPTION
## Summary
- update createSkill to accept `foundry.data.ItemSource`

## Testing
- `yarn test` *(fails: missing lockfile deps)*

------
https://chatgpt.com/codex/tasks/task_e_685eec21a50c8321a76ae6e7c059ce8d