### PR TITLE
Fix skill creation typing

### DIFF
--- a/src/vue/sheets/actor/character/SkillsTab.vue
+++ b/src/vue/sheets/actor/character/SkillsTab.vue
@@ -44,7 +44,9 @@ const deleteLabel = game.i18n.localize('Genesys.Labels.Delete');
 const addSkillLabel = game.i18n.localize('Genesys.Labels.AddSkill');
 
 async function addSkill() {
-        const skill = await toRaw(context.sheet).createSkill({ name: addSkillLabel, type: 'skill' });
+        const skill = await toRaw(context.sheet).createSkill(
+                { name: addSkillLabel, type: 'skill' } as foundry.data.ItemSource<'skill'>,
+        );
         await skill?.sheet?.render(true);
 }
 


### PR DESCRIPTION
## Summary
- cast new skill data to `foundry.data.ItemSource<'skill'>`

## Testing
- `yarn lint` *(fails: package not in lockfile)*
- `yarn test` *(fails: package not in lockfile)*
- `yarn build` *(fails: package not in lockfile)*

------
https://chatgpt.com/codex/tasks/task_e_685eef74a8d88321aa5480882b9570d4