### PR TITLE
Update vehicle skill roll options

### DIFF
--- a/src/vue/sheets/actor/vehicle/SkillsTab.vue
+++ b/src/vue/sheets/actor/vehicle/SkillsTab.vue
@@ -10,6 +10,8 @@ import AdversaryDataModel from '@/actor/data/AdversaryDataModel';
 import MinionDataModel from '@/actor/data/MinionDataModel';
 
 import DicePrompt from '@/app/DicePrompt';
+import type { DicePromptOptions } from '@/app/DicePrompt';
+import { Approach } from '@/data/Approaches';
 import Localized from '@/vue/components/Localized.vue';
 import SkillRanks from '@/vue/components/character/SkillRanks.vue';
 
@@ -133,10 +135,13 @@ function sortNames([left]: [string, any], [right]: [string, any]) {
 }
 
 async function rollSkillForActor(actor: GenesysActor, skill: GenesysItem<SkillDataModel>) {
-	if (actor.isOwner) {
-		const promptOptions = skill.pack ? { rollUnskilled: skill.systemData.characteristic } : {};
-		await DicePrompt.promptForRoll(actor, skill.name, promptOptions);
-	}
+        if (actor.isOwner) {
+                const promptOptions: DicePromptOptions | undefined =
+                        skill.pack
+                                ? { rollUnskilled: skill.systemData.characteristic as unknown as Approach }
+                                : undefined;
+                await DicePrompt.promptForRoll(actor, skill.name, promptOptions);
+        }
 }
 
 async function openActorSheet(actor: GenesysActor) {


### PR DESCRIPTION
## Summary
- update Vehicle SkillsTab to cast characteristic as Approach when setting roll options
- import Approach and DicePromptOptions

## Testing
- `yarn lint` *(fails: This package doesn't seem to be present in your lockfile)*
- `yarn test` *(fails: This package doesn't seem to be present in your lockfile)*

------
https://chatgpt.com/codex/tasks/task_e_685eef7615548321ac2e2943e0fb7f93