### PR TITLE
Fix GitHub release artifact name

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -29,4 +29,4 @@ jobs:
         with:
           files: |
             dist/system.json
-            genesys-*.zip
+            system.zip


### PR DESCRIPTION
## Summary
- correct asset filename in release workflow

## Testing
- `yarn test` *(fails: This package doesn't seem to be present in your lockfile)*

------
https://chatgpt.com/codex/tasks/task_e_685f10d5735c832181e907452e20b7d3