### PR TITLE
Add meta resource support

### DIFF
--- a/scripts/migrate-meta-resources.js
+++ b/scripts/migrate-meta-resources.js
@@ -1,0 +1,22 @@
+const fs = require('fs');
+const path = require('path');
+
+const PACK_DIR = path.join(__dirname, '..', 'public', 'packs');
+
+for (const file of fs.readdirSync(PACK_DIR)) {
+  if (!file.endsWith('.db')) continue;
+  const fullPath = path.join(PACK_DIR, file);
+  const lines = fs.readFileSync(fullPath, 'utf8').split('\n').filter(Boolean);
+  const updated = lines.map((line) => {
+    const data = JSON.parse(line);
+    if (data.type === 'character' && data.system) {
+      if (data.system.contacts === undefined) data.system.contacts = 0;
+      if (data.system.intel === undefined) data.system.intel = 0;
+      if (data.system.will === undefined) data.system.will = 0;
+      if (!Array.isArray(data.system.resourceHistory)) data.system.resourceHistory = [];
+    }
+    return JSON.stringify(data);
+  });
+  fs.writeFileSync(fullPath, updated.join('\n') + '\n', 'utf8');
+  console.log(`Migrated ${file}`);
+}

--- a/src/actor/data/CharacterDataModel.ts
+++ b/src/actor/data/CharacterDataModel.ts
@@ -84,8 +84,12 @@ export default abstract class CharacterDataModel extends foundry.abstract.DataMo
        abstract currency: number;
        abstract resource: number;
        abstract resourceName: string;
+       abstract contacts: number;
+       abstract intel: number;
+       abstract will: number;
        abstract xp: number;
        abstract xpHistory: { amount: number; note?: string; target?: string }[];
+       abstract resourceHistory: { resource: string; amount: number; note?: string }[];
        abstract abilities: NarrativeAbility[];
        abstract notes: string;
 	abstract superCharacteristics: Set<Characteristic>;
@@ -263,6 +267,84 @@ export default abstract class CharacterDataModel extends foundry.abstract.DataMo
 
                 return true;
         }
+
+       async gainContacts(amount: number, note?: string) {
+               await (this.parent as unknown as Actor).update({
+                       'system.contacts': this.contacts + amount,
+                       'system.resourceHistory': [
+                               ...this.resourceHistory,
+                               { resource: 'contacts', amount, note },
+                       ],
+               });
+       }
+
+       async spendContacts(amount: number, note?: string) {
+               if (this.contacts < amount) {
+                       return false;
+               }
+
+               await (this.parent as unknown as Actor).update({
+                       'system.contacts': this.contacts - amount,
+                       'system.resourceHistory': [
+                               ...this.resourceHistory,
+                               { resource: 'contacts', amount: -amount, note },
+                       ],
+               });
+
+               return true;
+       }
+
+       async gainIntel(amount: number, note?: string) {
+               await (this.parent as unknown as Actor).update({
+                       'system.intel': this.intel + amount,
+                       'system.resourceHistory': [
+                               ...this.resourceHistory,
+                               { resource: 'intel', amount, note },
+                       ],
+               });
+       }
+
+       async spendIntel(amount: number, note?: string) {
+               if (this.intel < amount) {
+                       return false;
+               }
+
+               await (this.parent as unknown as Actor).update({
+                       'system.intel': this.intel - amount,
+                       'system.resourceHistory': [
+                               ...this.resourceHistory,
+                               { resource: 'intel', amount: -amount, note },
+                       ],
+               });
+
+               return true;
+       }
+
+       async gainWill(amount: number, note?: string) {
+               await (this.parent as unknown as Actor).update({
+                       'system.will': this.will + amount,
+                       'system.resourceHistory': [
+                               ...this.resourceHistory,
+                               { resource: 'will', amount, note },
+                       ],
+               });
+       }
+
+       async spendWill(amount: number, note?: string) {
+               if (this.will < amount) {
+                       return false;
+               }
+
+               await (this.parent as unknown as Actor).update({
+                       'system.will': this.will - amount,
+                       'system.resourceHistory': [
+                               ...this.resourceHistory,
+                               { resource: 'will', amount: -amount, note },
+                       ],
+               });
+
+               return true;
+       }
 
 	get talentPyramidTotals() {
 		const allTalents = (<CharacterActor>(<unknown>this.parent)).items.filter((i) => i.type === 'talent') as GenesysItem<TalentDataModel>[];
@@ -486,21 +568,31 @@ export default abstract class CharacterDataModel extends foundry.abstract.DataMo
 				threshold: new fields.NumberField({ integer: true, initial: 0 }),
 			}),
                         currency: new fields.NumberField({ initial: 500 }),
-                        resource: new fields.NumberField({ integer: true, initial: 0 }),
-                        resourceName: new fields.StringField(),
-                        xp: new fields.NumberField({ integer: true, initial: 0 }),
-                        xpHistory: new fields.ArrayField(
-                                new fields.SchemaField({
-                                        amount: new fields.NumberField({ integer: true, initial: 0 }),
-                                        note: new fields.StringField(),
-                                        target: new fields.StringField(),
-                                }),
-                        ),
-                        abilities: new fields.ArrayField(
-                                new fields.SchemaField({
-                                        name: new fields.StringField(),
-                                        description: new fields.HTMLField(),
-                                        cost: new fields.NumberField({ integer: true, initial: 0 }),
+                       resource: new fields.NumberField({ integer: true, initial: 0 }),
+                       resourceName: new fields.StringField(),
+                       contacts: new fields.NumberField({ integer: true, initial: 0 }),
+                       intel: new fields.NumberField({ integer: true, initial: 0 }),
+                       will: new fields.NumberField({ integer: true, initial: 0 }),
+                       xp: new fields.NumberField({ integer: true, initial: 0 }),
+                       xpHistory: new fields.ArrayField(
+                               new fields.SchemaField({
+                                       amount: new fields.NumberField({ integer: true, initial: 0 }),
+                                       note: new fields.StringField(),
+                                       target: new fields.StringField(),
+                               }),
+                       ),
+                       resourceHistory: new fields.ArrayField(
+                               new fields.SchemaField({
+                                       resource: new fields.StringField(),
+                                       amount: new fields.NumberField({ integer: true, initial: 0 }),
+                                       note: new fields.StringField(),
+                               }),
+                       ),
+                       abilities: new fields.ArrayField(
+                               new fields.SchemaField({
+                                       name: new fields.StringField(),
+                                       description: new fields.HTMLField(),
+                                       cost: new fields.NumberField({ integer: true, initial: 0 }),
                                 }),
                         ),
                         superCharacteristics: new fields.SetField(new fields.StringField()),

--- a/yaml/lang/en.yml
+++ b/yaml/lang/en.yml
@@ -510,3 +510,6 @@ Genesys:
     Select: Select
     PerformCheck: Perform Check
     CustomFields: Custom Fields
+    Contacts: Contacts
+    Intel: Intel
+    Will: Will

--- a/yaml/lang/es.yml
+++ b/yaml/lang/es.yml
@@ -502,3 +502,6 @@ Genesys:
     FiringArc: Sector de tiro
     Select: Seleccionar
     PerformCheck: Realizar tirada
+    Contacts: Contactos
+    Intel: Inteligencia
+    Will: Voluntad

--- a/yaml/lang/fr.yml
+++ b/yaml/lang/fr.yml
@@ -501,3 +501,6 @@ Genesys:
     FiringArc: Arc de tir
     Select: Sélection
     PerformCheck: Perform Check
+    Contacts: Contacts
+    Intel: Renseignements
+    Will: Volonté

--- a/yaml/lang/ru.yml
+++ b/yaml/lang/ru.yml
@@ -521,4 +521,7 @@ Genesys:
     Resource: Ресурс
     UseAbility: Использовать
     CustomFields: Доп. поля
+    Contacts: Связи
+    Intel: Разведданные
+    Will: Воля
 


### PR DESCRIPTION
## Summary
- add `contacts`, `intel`, `will` and history tracking to `CharacterDataModel`
- implement resource gain/spend helpers
- provide migration script for existing actors
- localise new labels in all languages

## Testing
- `yarn lint` *(fails: package not in lockfile)*
- `yarn test` *(fails: package not in lockfile)*

------
https://chatgpt.com/codex/tasks/task_e_68614ee99cc88321921d284b574d141f