### PR TITLE
Add physical and magical defense fields

### DIFF
--- a/scripts/migrate-hisuya-core.js
+++ b/scripts/migrate-hisuya-core.js
@@ -16,6 +16,8 @@ for (const file of fs.readdirSync(PACK_DIR)) {
         const strainVal = data.system.strain.value ?? 0;
         data.system.resource = strainVal;
       }
+      if (data.system.physDefense === undefined) data.system.physDefense = 0;
+      if (data.system.magicDefense === undefined) data.system.magicDefense = 0;
     }
     return JSON.stringify(data);
   });

--- a/src/actor/data/CharacterDataModel.ts
+++ b/src/actor/data/CharacterDataModel.ts
@@ -72,9 +72,11 @@ type RelevantTypes = {
 export default abstract class CharacterDataModel extends foundry.abstract.DataModel implements IHasPreCreate<CharacterActor> {
         abstract characteristics: CharacteristicsContainer;
         abstract approaches: ApproachesContainer;
-	abstract soak: number;
-	abstract defense: Defense;
-	abstract wounds: CombatPool;
+       abstract soak: number;
+       abstract defense: Defense;
+       abstract physDefense: number;
+       abstract magicDefense: number;
+       abstract wounds: CombatPool;
 	abstract strain: CombatPool;
 	abstract illustration: string;
 	abstract motivations: Motivations;
@@ -163,17 +165,25 @@ export default abstract class CharacterDataModel extends foundry.abstract.DataMo
 	/**
 	 * Total value for Defense (base defenses + armor).
 	 */
-	get totalDefense(): Defense {
-		const armorDefense = (<CharacterActor>(<unknown>this.parent)).items
-			.filter((i) => i.type === 'armor' && (<ArmorItem>i).systemData.state === 'equipped')
-			.map((i) => (<ArmorItem>i).systemData.defense)
-			.reduce((total, d) => total + d, 0);
+        get totalDefense(): Defense {
+                const armorDefense = (<CharacterActor>(<unknown>this.parent)).items
+                        .filter((i) => i.type === 'armor' && (<ArmorItem>i).systemData.state === 'equipped')
+                        .map((i) => (<ArmorItem>i).systemData.defense)
+                        .reduce((total, d) => total + d, 0);
 
-		return {
-			ranged: Math.min(4, this.defense.ranged + armorDefense),
-			melee: Math.min(4, this.defense.melee + armorDefense),
-		};
-	}
+                return {
+                        ranged: Math.min(4, this.defense.ranged + armorDefense),
+                        melee: Math.min(4, this.defense.melee + armorDefense),
+                };
+        }
+
+       get totalPhysDefense(): number {
+               return this.physDefense;
+       }
+
+       get totalMagicDefense(): number {
+               return this.magicDefense;
+       }
 
 	/**
 	 * Amount of XP the character has available to spend right now.
@@ -513,14 +523,16 @@ export default abstract class CharacterDataModel extends foundry.abstract.DataMo
 				presence: new fields.NumberField({ integer: true, initial: 0 }),
 			}),
 			soak: new fields.NumberField({ integer: true, initial: 0 }),
-			defense: new fields.SchemaField({
-				melee: new fields.NumberField({ integer: true, initial: 0 }),
-				ranged: new fields.NumberField({ integer: true, initial: 0 }),
-			}),
-			wounds: new fields.SchemaField({
-				value: new fields.NumberField({ integer: true, initial: 0 }),
-				max: new fields.NumberField({ integer: true, initial: 0 }),
-			}),
+                       defense: new fields.SchemaField({
+                               melee: new fields.NumberField({ integer: true, initial: 0 }),
+                               ranged: new fields.NumberField({ integer: true, initial: 0 }),
+                       }),
+                       physDefense: new fields.NumberField({ integer: true, initial: 0 }),
+                       magicDefense: new fields.NumberField({ integer: true, initial: 0 }),
+                       wounds: new fields.SchemaField({
+                               value: new fields.NumberField({ integer: true, initial: 0 }),
+                               max: new fields.NumberField({ integer: true, initial: 0 }),
+                       }),
 			strain: new fields.SchemaField({
 				value: new fields.NumberField({ integer: true, initial: 0 }),
 				max: new fields.NumberField({ integer: true, initial: 0 }),

--- a/src/vue/sheets/actor/CharacterSheet.vue
+++ b/src/vue/sheets/actor/CharacterSheet.vue
@@ -68,12 +68,24 @@ onBeforeUpdate(updateEffects);
                                 label="Genesys.Labels.Defense"
                                 primary-label="Genesys.Labels.DefenseRanged"
                                 :value="system.totalDefense.ranged"
-				has-secondary
-				secondary-label="Genesys.Labels.DefenseMelee"
-				:secondary-value="system.totalDefense.melee"
-				read-only
-			/>
-		</section>
+                                has-secondary
+                                secondary-label="Genesys.Labels.DefenseMelee"
+                                :secondary-value="system.totalDefense.melee"
+                                read-only
+                        />
+
+                        <CombatStat
+                                label="Genesys.Labels.PhysDefense"
+                                :value="system.totalPhysDefense"
+                                read-only
+                        />
+
+                        <CombatStat
+                                label="Genesys.Labels.MagicDefense"
+                                :value="system.totalMagicDefense"
+                                read-only
+                        />
+                </section>
 
 		<nav class="sheet-tabs" data-group="primary">
 			<div class="spacer"></div>

--- a/yaml/lang/en.yml
+++ b/yaml/lang/en.yml
@@ -405,6 +405,8 @@ Genesys:
     MeleeDefense: Melee Defense
     DefenseRanged: Ranged
     RangedDefense: Ranged Defense
+    PhysDefense: Physical Defense
+    MagicDefense: Magic Defense
     TotalXP: Total XP
     AvailableXP: Available XP
     Characteristic: Characteristic

--- a/yaml/lang/es.yml
+++ b/yaml/lang/es.yml
@@ -398,6 +398,8 @@ Genesys:
     MeleeDefense: Defensa cuerpo a cuerpo
     DefenseRanged: A distancia
     RangedDefense: Defensa a distancia
+    PhysDefense: Defensa física
+    MagicDefense: Defensa mágica
     TotalXP: PE totales
     AvailableXP: PE disponibles
     Characteristic: Característica

--- a/yaml/lang/fr.yml
+++ b/yaml/lang/fr.yml
@@ -397,6 +397,8 @@ Genesys:
     MeleeDefense: Défense de mélée
     DefenseRanged: Distance
     RangedDefense: Défense à distance
+    PhysDefense: Défense physique
+    MagicDefense: Défense magique
     TotalXP: XP Total
     AvailableXP: XP disponible
     Characteristic: Caractéristique

--- a/yaml/lang/ru.yml
+++ b/yaml/lang/ru.yml
@@ -422,6 +422,8 @@ Genesys:
     MeleeDefense: Защита в ближнем бою
     DefenseRanged: Дальний бой
     RangedDefense: Защита в дальнем бою
+    PhysDefense: Физическая защита
+    MagicDefense: Магическая защита
     TotalXP: Всего опыта
     AvailableXP: Доступный опыт
     Characteristic: Характеристика


### PR DESCRIPTION
## Summary
- add new defense fields to character data model and expose computed totals
- show Physical/Magical Defense on the character sheet
- migrate packs so missing defense values get zeros
- localise new labels in all languages

## Testing
- `yarn lint` *(fails: This package doesn't seem to be present in your lockfile)*
- `yarn test` *(fails: This package doesn't seem to be present in your lockfile)*

------
https://chatgpt.com/codex/tasks/task_e_6861546f0a14832183519c6f725400a5