### PR TITLE
Implement XP log and remove old strain field

### DIFF
--- a/scripts/migrate-hisuya-core.js
+++ b/scripts/migrate-hisuya-core.js
@@ -11,11 +11,22 @@ for (const file of fs.readdirSync(PACK_DIR)) {
     const data = JSON.parse(line);
     if (data.type === 'character' && data.system) {
       if (data.system.xp === undefined) data.system.xp = 0;
-      if (!Array.isArray(data.system.xpHistory)) data.system.xpHistory = [];
+      if (!Array.isArray(data.system.xpHistory)) {
+        data.system.xpHistory = [];
+      } else {
+        data.system.xpHistory = data.system.xpHistory.map((e) => ({
+          amount: e.amount ?? 0,
+          type: e.amount > 0 ? 'Gain' : 'Spend',
+          target: e.target || '',
+          description: e.note || '',
+          timestamp: e.timestamp || Date.now(),
+        }));
+      }
       if (data.system.resource === undefined && data.system.strain) {
         const strainVal = data.system.strain.value ?? 0;
         data.system.resource = strainVal;
       }
+      delete data.system.strain;
     }
     return JSON.stringify(data);
   });

--- a/src/actor/data/character/ExperienceJournal.ts
+++ b/src/actor/data/character/ExperienceJournal.ts
@@ -125,16 +125,10 @@ export async function removeJournalEntry(actor: GenesysActor<CharacterDataModel>
 				return;
 			}
 
-			// Reduce Wound Threshold or Strain Threshold.
-			switch (data.characteristic) {
-				case Characteristic.Brawn:
-					additionalChangeKeys['system.wounds.max'] = (actor.systemData._source.wounds as CombatPool).max - 1;
-					break;
-
-				case Characteristic.Willpower:
-					additionalChangeKeys['system.strain.max'] = (actor.systemData._source.strain as CombatPool).max - 1;
-					break;
-			}
+                        // Reduce Wound Threshold when lowering characteristics.
+                        if (data.characteristic === Characteristic.Brawn) {
+                                additionalChangeKeys['system.wounds.max'] = (actor.systemData._source.wounds as CombatPool).max - 1;
+                        }
 
 			additionalChangeKeys[`system.characteristics.${data.characteristic}`] = data.rank - 1;
 			break;

--- a/src/actor/sheets/CharacterSheet.ts
+++ b/src/actor/sheets/CharacterSheet.ts
@@ -246,8 +246,7 @@ export default class CharacterSheet extends VueSheet(GenesysActorSheet<Character
 			'system.characteristics.willpower': workingData.characteristics.willpower,
 			'system.characteristics.presence': workingData.characteristics.presence,
 
-			'system.wounds.max': workingData.wounds.max,
-			'system.strain.max': workingData.strain.max,
+                        'system.wounds.max': workingData.wounds.max,
 
 			'system.experienceJournal.entries': workingData.experienceJournal.entries,
 		});
@@ -273,9 +272,8 @@ export default class CharacterSheet extends VueSheet(GenesysActorSheet<Character
 		workingData.characteristics.willpower += archetypeData.characteristics.willpower;
 		workingData.characteristics.presence += archetypeData.characteristics.presence;
 
-		// Wound & Strain Thresholds
-		workingData.wounds.max += archetypeData.woundThreshold + archetypeData.characteristics.brawn;
-		workingData.strain.max += archetypeData.strainThreshold + archetypeData.characteristics.willpower;
+                // Wound Threshold
+                workingData.wounds.max += archetypeData.woundThreshold + archetypeData.characteristics.brawn;
 
 		// Granted Items
 		const items = archetypeData.grantedItems;
@@ -326,9 +324,8 @@ export default class CharacterSheet extends VueSheet(GenesysActorSheet<Character
 		workingData.characteristics.willpower -= archetypeData.characteristics.willpower;
 		workingData.characteristics.presence -= archetypeData.characteristics.presence;
 
-		// Wound & Strain Thresholds
-		workingData.wounds.max -= archetypeData.woundThreshold + archetypeData.characteristics.brawn;
-		workingData.strain.max -= archetypeData.strainThreshold + archetypeData.characteristics.willpower;
+                // Wound Threshold
+                workingData.wounds.max -= archetypeData.woundThreshold + archetypeData.characteristics.brawn;
 
 		// Remove starting XP from Experience Journal.
 		workingData.experienceJournal.entries = workingData.experienceJournal.entries.slice(1);

--- a/src/vue/sheets/actor/CharacterSheet.vue
+++ b/src/vue/sheets/actor/CharacterSheet.vue
@@ -53,15 +53,6 @@ onBeforeUpdate(updateEffects);
                                 :secondary-value="system.wounds.value"
                         />
 
-                        <CombatStat
-                                label="Genesys.Labels.Strain"
-                                primary-label="Genesys.Labels.Threshold"
-                                :value="system.strain.max"
-                                has-secondary
-                                secondary-label="Genesys.Labels.Current"
-                                secondary-name="system.strain.value"
-                                :secondary-value="system.strain.value"
-                        />
 
                         <CombatStat :label="system.resourceName" :value="system.resource" />
 
@@ -131,7 +122,7 @@ onBeforeUpdate(updateEffects);
 	gap: 0.5em;
 }
 
-// Container for the character's secondary combat stats (wounds, strain, etc.)
+// Container for the character's secondary combat stats (wounds, resource, etc.)
 .combat-stat-row {
 	// By default, evenly space the items across the full sheet width.
 	display: flex;


### PR DESCRIPTION
## Summary
- track XP history with timestamped gain/spend records
- drop deprecated `strain` pool from character data and sheet
- migrate existing data to new format

## Testing
- `yarn lint` *(fails: package missing in lockfile)*
- `yarn test` *(fails: package missing in lockfile)*

------
https://chatgpt.com/codex/tasks/task_e_68613a10daa08321a5230c7d3f8041ef