### PR TITLE
Fix skill roll typing errors

### DIFF
--- a/src/vue/sheets/actor/character/SkillsTab.vue
+++ b/src/vue/sheets/actor/character/SkillsTab.vue
@@ -64,7 +64,7 @@ const addSkillLabel = game.i18n.localize('Genesys.Labels.AddSkill');
 
 async function addSkill() {
         const skill = await toRaw(context.sheet).createSkill(
-                { name: addSkillLabel, type: 'skill' } as foundry.data.ItemSource<
+                { name: addSkillLabel, type: 'skill' } as unknown as foundry.data.ItemSource<
                         'skill',
                         SkillDataModel['_source']
                 >,

--- a/src/vue/sheets/actor/vehicle/SkillsTab.vue
+++ b/src/vue/sheets/actor/vehicle/SkillsTab.vue
@@ -137,12 +137,11 @@ function sortNames([left]: [string, any], [right]: [string, any]) {
 
 async function rollSkillForActor(actor: GenesysActor, skill: GenesysItem<SkillDataModel>) {
         if (actor.isOwner) {
-                const approach = await ApproachPrompt.promptForApproach();
+                const approach: Approach | undefined = await ApproachPrompt.promptForApproach();
                 if (!approach) {
                         return;
                 }
-                const promptOptions: DicePromptOptions = { rollUnskilled: approach };
-                await DicePrompt.promptForRoll(actor, skill.name, promptOptions);
+                await DicePrompt.promptForRoll(actor, skill.name, { rollUnskilled: approach });
         }
 }
 


### PR DESCRIPTION
## Summary
- update vehicle skill tab roll function typing
- cast new skill data correctly when creating a skill

## Testing
- `yarn lint` *(fails: package not present in lockfile)*
- `yarn build` *(fails: package not present in lockfile)*

------
https://chatgpt.com/codex/tasks/task_e_68615d4239108321ac10388d761fd9f9