### PR TITLE
Fix skill creation and approach roll

### DIFF
--- a/src/vue/sheets/actor/character/SkillsTab.vue
+++ b/src/vue/sheets/actor/character/SkillsTab.vue
@@ -63,12 +63,23 @@ const deleteLabel = game.i18n.localize('Genesys.Labels.Delete');
 const addSkillLabel = game.i18n.localize('Genesys.Labels.AddSkill');
 
 async function addSkill() {
-        const skill = await toRaw(context.sheet).createSkill(
-                { name: addSkillLabel, type: 'skill' } as unknown as foundry.data.ItemSource<
-                        'skill',
-                        SkillDataModel['_source']
-                >,
-        );
+        const stubSkill: foundry.data.ItemSource<'skill', SkillDataModel['_source']> = {
+                _id: foundry.utils.randomID(),
+                name: addSkillLabel,
+                type: 'skill',
+                img: 'icons/svg/book.svg',
+                system: {
+                        description: '',
+                        source: '',
+                        category: 'general',
+                        initiative: false,
+                        career: false,
+                        rank: 0,
+                },
+                effects: [],
+                flags: {},
+        };
+        const skill = await toRaw(context.sheet).createSkill(stubSkill);
         await skill?.sheet?.render(true);
 }
 

--- a/src/vue/sheets/actor/vehicle/SkillsTab.vue
+++ b/src/vue/sheets/actor/vehicle/SkillsTab.vue
@@ -141,7 +141,9 @@ async function rollSkillForActor(actor: GenesysActor, skill: GenesysItem<SkillDa
                 if (!approach) {
                         return;
                 }
-                await DicePrompt.promptForRoll(actor, skill.name, { rollUnskilled: approach });
+                await DicePrompt.promptForRoll(actor, skill.name, {
+                        rollUnskilled: approach as Approach,
+                });
         }
 }
 


### PR DESCRIPTION
## Summary
- create a full ItemSource when adding a new skill
- pass Approach to vehicle skill rolls

## Testing
- `vue-tsc -p tsconfig.json --noEmit` *(fails: package not in lockfile)*
- `yarn test` *(fails: package not in lockfile)*

------
https://chatgpt.com/codex/tasks/task_e_68616181b69883219d5bac50665d0d16