### PR TITLE
Fix skill creation and configure CI

### DIFF
--- a/.github/workflows/codex.yml
+++ b/.github/workflows/codex.yml
@@ -1,0 +1,24 @@
+name: Codex CI
+
+on:
+  pull_request:
+  push:
+    branches: [ work ]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v3
+      - name: Setup Node
+        uses: actions/setup-node@v3
+        with:
+          node-version: 18
+          cache: 'yarn'
+      - name: Install deps
+        run: yarn install --frozen-lockfile
+      - name: Type check
+        run: yarn vue-tsc -p tsconfig.json --noEmit
+      - name: Build
+        run: yarn build

--- a/src/vue/sheets/actor/character/SkillsTab.vue
+++ b/src/vue/sheets/actor/character/SkillsTab.vue
@@ -20,7 +20,6 @@ import GenesysRoller from '@/dice/GenesysRoller';
 import ContextMenu from '@/vue/components/ContextMenu.vue';
 import MenuItem from '@/vue/components/MenuItem.vue';
 import MasonryWall from '@yeger/vue-masonry-wall';
-import { Approach } from '@/data/Approaches';
 
 const context = inject<ActorSheetContext<CharacterDataModel, CharacterSheet>>(RootContext)!;
 const system = computed(() => context.data.actor.systemData);
@@ -63,12 +62,26 @@ const deleteLabel = game.i18n.localize('Genesys.Labels.Delete');
 const addSkillLabel = game.i18n.localize('Genesys.Labels.AddSkill');
 
 async function addSkill() {
-        const skill = await toRaw(context.sheet).createSkill(
-                { name: addSkillLabel, type: 'skill' } as unknown as foundry.data.ItemSource<
-                        'skill',
-                        SkillDataModel['_source']
-                >,
-        );
+        const stubSkill: foundry.data.ItemSource<'skill', SkillDataModel['_source']> = {
+                _id: foundry.utils.randomID(),
+                name: addSkillLabel,
+                type: 'skill',
+                img: 'icons/svg/book.svg',
+                system: {
+                        description: '',
+                        source: '',
+                        category: 'general',
+                        initiative: false,
+                        career: false,
+                        rank: 0,
+                },
+                effects: [],
+                ownership: { default: CONST.DOCUMENT_OWNERSHIP_LEVELS.OWNER },
+                sort: 0,
+                folder: null,
+                flags: {},
+        };
+        const skill = await toRaw(context.sheet).createSkill(stubSkill);
         await skill?.sheet?.render(true);
 }
 

--- a/src/vue/sheets/actor/vehicle/SkillsTab.vue
+++ b/src/vue/sheets/actor/vehicle/SkillsTab.vue
@@ -10,7 +10,6 @@ import AdversaryDataModel from '@/actor/data/AdversaryDataModel';
 import MinionDataModel from '@/actor/data/MinionDataModel';
 
 import DicePrompt from '@/app/DicePrompt';
-import type { DicePromptOptions } from '@/app/DicePrompt';
 import ApproachPrompt from '@/app/ApproachPrompt';
 import { Approach } from '@/data/Approaches';
 import Localized from '@/vue/components/Localized.vue';
@@ -141,7 +140,9 @@ async function rollSkillForActor(actor: GenesysActor, skill: GenesysItem<SkillDa
                 if (!approach) {
                         return;
                 }
-                await DicePrompt.promptForRoll(actor, skill.name, { rollUnskilled: approach });
+                await DicePrompt.promptForRoll(actor, skill.name, {
+                        rollUnskilled: approach as Approach,
+                });
         }
 }
 


### PR DESCRIPTION
## Summary
- complete ItemSource data when adding a new skill
- run yarn install and build steps via a Codex CI workflow

## Testing
- `yarn vue-tsc -p tsconfig.json --noEmit` *(fails: package not in lockfile)*
- `yarn build` *(fails: package not in lockfile)*

------
https://chatgpt.com/codex/tasks/task_e_68616181b69883219d5bac50665d0d16