### PR TITLE
fix tsconfig for noEmit runs

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -4,9 +4,8 @@
 		"module": "ES2022",
 		"moduleResolution": "Node",
 
-		"baseUrl": ".",
-		"emitDeclarationOnly": true,
-		"declaration": true,
+                "baseUrl": ".",
+                "declaration": true,
 		"declarationDir": "lib",
 
 		"strict": true,


### PR DESCRIPTION
## Summary
- allow running vue-tsc with `--noEmit` by removing `emitDeclarationOnly` from `tsconfig.json`

## Testing
- `yarn test` *(fails: package not in lockfile)*
- `yarn vue-tsc -p tsconfig.json --noEmit` *(fails: package not in lockfile)*

------
https://chatgpt.com/codex/tasks/task_e_68616e88dcb48321abffd4898ddac7d5