### PR TITLE
Fix skill creation stub

### DIFF
--- a/src/vue/sheets/actor/character/SkillsTab.vue
+++ b/src/vue/sheets/actor/character/SkillsTab.vue
@@ -63,24 +63,29 @@ const deleteLabel = game.i18n.localize('Genesys.Labels.Delete');
 const addSkillLabel = game.i18n.localize('Genesys.Labels.AddSkill');
 
 async function addSkill() {
-        const stubSkill: foundry.data.ItemSource<'skill', SkillDataModel['_source']> = {
-                _id: foundry.utils.randomID(),
-                name: addSkillLabel,
-                type: 'skill',
-                img: 'icons/svg/book.svg',
-                system: {
-                        description: '',
-                        source: '',
-                        category: 'general',
-                        initiative: false,
-                        career: false,
-                        rank: 0,
-                },
-                effects: [],
-                flags: {},
-        };
-        const skill = await toRaw(context.sheet).createSkill(stubSkill);
-        await skill?.sheet?.render(true);
+  const stubSkill: foundry.data.ItemSource<'skill', SkillDataModel['_source']> = {
+    _id: foundry.utils.randomID(),
+    name: addSkillLabel,
+    type: 'skill',
+    img: 'icons/svg/book.svg',
+    system: {
+      description: '',
+      source: '',
+      category: 'general',
+      initiative: false,
+      career: false,
+      rank: 0,
+    },
+    effects: [],
+    /* обязательные поля ItemSource — иначе vue-tsc ругается */
+    ownership: { default: CONST.DOCUMENT_OWNERSHIP_LEVELS.OWNER },
+    sort: 0,
+    folder: null,
+    flags: {},
+  };
+  // приводим тип, чтобы были методы GenesysItem
+  const skill = (await toRaw(context.sheet).createSkill(stubSkill)) as unknown as GenesysItem<SkillDataModel>;
+  await skill?.sheet?.render(true);
 }
 
 async function rollSkill(skill: GenesysItem<SkillDataModel>) {


### PR DESCRIPTION
## Summary
- add missing `sort`/`folder`/`ownership` to stub skill
- ensure `createSkill` result is typed as `GenesysItem`

## Testing
- `npx vue-tsc -p tsconfig.json --noEmit` *(fails: 403 Forbidden)*
- `yarn build` *(fails: package not in lockfile)*
- `npx vite build` *(fails: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_6861732da4fc83218c53fcada5077e5a