### PR TITLE
fix skill spend xp call

### DIFF
--- a/src/vue/sheets/actor/character/SkillsTab.vue
+++ b/src/vue/sheets/actor/character/SkillsTab.vue
@@ -110,7 +110,7 @@ async function purchaseSkillRank(skill: GenesysItem<SkillDataModel>) {
                 return;
         }
 
-        const spent = await toRaw(context.data.actor).system.spendXP(1, 'skill:' + skill.name);
+        const spent = await toRaw(context.data.actor).systemData.spendXP(1, 'skill:' + skill.name);
         if (!spent) {
                 return;
         }


### PR DESCRIPTION
## Summary
- fix SkillTab actor system reference

## Testing
- `yarn lint` *(fails: package not present in lockfile)*
- `yarn test` *(fails: package not present in lockfile)*

------
https://chatgpt.com/codex/tasks/task_e_686175ab169883218c97a819db6feb1d