### PR TITLE
Fix spendXP calls

### DIFF
--- a/src/vue/sheets/actor/character/SkillsTab.vue
+++ b/src/vue/sheets/actor/character/SkillsTab.vue
@@ -110,14 +110,11 @@ async function purchaseSkillRank(skill: GenesysItem<SkillDataModel>) {
                 return;
         }
 
-        const spent = await toRaw(context.data.actor).systemData.spendXP(1, 'skill:' + skill.name);
-        if (!spent) {
-                return;
-        }
+       await toRaw(context.data.actor).systemData.spendXP(1, 'skill:' + skill.name);
 
-        await toRaw(skill).update({
-                'system.rank': skill.systemData.rank + 1,
-        });
+       await toRaw(skill).update({
+               'system.rank': skill.systemData.rank + 1,
+       });
 }
 
 async function toggleCareerSkill(skill: GenesysItem<SkillDataModel>) {


### PR DESCRIPTION
## Summary
- remove checks on spendXP return value in character SkillsTab

## Testing
- `yarn build` *(fails: package not in lockfile)*

------
https://chatgpt.com/codex/tasks/task_e_68617b8b75d08321afb0db8423d55b3a