### PR TITLE
Handle jQuery dependency during build

### DIFF
--- a/vite.config.ts
+++ b/vite.config.ts
@@ -41,19 +41,25 @@ export default defineConfig({
 		},
 	},
 	publicDir: 'public',
-	build: {
-		outDir: 'dist',
-		emptyOutDir: true,
-		sourcemap: true,
-		// Avoiding minification is important, because we don't want names of globals/etc. to be mangled.
-		minify: false,
-		lib: {
-			name: 'Genesys',
-			entry: 'src/Genesys.ts',
-			formats: ['es'], // ES Modules
-			fileName: 'Genesys',
-		},
-	},
+        build: {
+                outDir: 'dist',
+                emptyOutDir: true,
+                sourcemap: true,
+                // Avoiding minification is important, because we don't want names of globals/etc. to be mangled.
+                minify: false,
+                lib: {
+                        name: 'Genesys',
+                        entry: 'src/Genesys.ts',
+                        formats: ['es'], // ES Modules
+                        fileName: 'Genesys',
+                },
+                rollupOptions: {
+                        external: ['jquery'],
+                        output: {
+                                globals: { jquery: 'jQuery' },
+                        },
+                },
+        },
 	plugins: [pluginVue()],
 	resolve: {
 		alias: [{ find: '@', replacement: path.resolve(__dirname, 'src') }, { find: '@scss', replacement: path.resolve(__dirname, 'src/scss') }, ...devOnlyAliases, ...releaseOnlyAliases],


### PR DESCRIPTION
## Summary
- treat jQuery as an external global for rollup to avoid missing module

## Testing
- `yarn lint` *(fails: package not present in lockfile)*
- `yarn test` *(fails: package not present in lockfile)*
- `yarn release` *(fails: package not present in lockfile)*

------
https://chatgpt.com/codex/tasks/task_e_6861ad4aa1588321811c98e2d19f4f32